### PR TITLE
fix dependency issue

### DIFF
--- a/lLyrics/lLyrics.plugin
+++ b/lLyrics/lLyrics.plugin
@@ -2,6 +2,7 @@
 Loader=python
 Module=lLyrics
 IAge=2
+Depends=rb
 Name=lLyrics
 Description=Displays lyrics in the right sidebar
 Description[de]=Zeigt Liedtexte in der rechten Seitenleiste an


### PR DESCRIPTION
occasionally the following error is observed when firing up rhythmbox which prevents llyrics being loaded:

<pre>
dad@precise64:~/.local/share/rhythmbox/plugins/coverart_search_providers$ rhythmbox
Traceback (most recent call last):
  File "/usr/lib/rhythmbox/plugins/llyrics/lLyrics.py", line 49, in <module>
    import lLyrics_rb3compat as Compat
  File "/usr/lib/rhythmbox/plugins/llyrics/lLyrics_rb3compat.py", line 30, in <module>
    import rb
ImportError: No module named rb

(rhythmbox:3153): libpeas-WARNING **: Error loading plugin 'lLyrics'
</pre>


fix is simple - just ensure you have the internal rb dependency in the plugin file.
