### PR TITLE
fix occasional crash on startup

### DIFF
--- a/lLyrics/lLyrics.plugin
+++ b/lLyrics/lLyrics.plugin
@@ -3,6 +3,7 @@ Loader=python
 Module=lLyrics
 IAge=2
 Name=lLyrics
+Depends=rb
 Description=Displays lyrics in the sidebar
 Description[de]=Zeigt Liedtexte in der Seitenleiste an
 Authors=Timo Loewe <timoloewe91@gmail.com>


### PR DESCRIPTION
tiny fix for the following error reported to me via a user of your plugin:

<pre>
rhythmbox
Traceback (most recent call last):
  File "/usr/lib/rhythmbox/plugins/llyrics/lLyrics.py", line 43, in <module>
    from lLyrics_rb3compat import ActionGroup
  File "/usr/lib/rhythmbox/plugins/llyrics/lLyrics_rb3compat.py", line 30, in <module>
    import rb
ImportError: No module named rb

(rhythmbox:11783): libpeas-WARNING **: Error loading plugin 'lLyrics'
</pre>
