### PR TITLE
Better detection of byte encoding (charset) based in regular expression.

### DIFF
--- a/lLyrics/Util.py
+++ b/lLyrics/Util.py
@@ -92,11 +92,11 @@ def bytes_to_string(data):
     try:
         partialString = data.decode(encoding, 'replace')
         try:
-            charSetRegex = re.compile("charset=\"?([a-zA-Z0-9\\-]*)\"?")
-            results = charSetRegex.search(partialString)
+            bytes_to_string.charSetRegex = re.compile("charset=\"?([a-zA-Z0-9\\-]*)\"?")
+            results = bytes_to_string.charSetRegex.search(partialString)
             if(results != None):
                 encoding = results.group(1)
-                string = data.decode(encoding, 'replace')
+                string = data.decode(encoding)
             else:
                 string = partialString
         except:

--- a/lLyrics/Util.py
+++ b/lLyrics/Util.py
@@ -88,17 +88,28 @@ def time_to_seconds(time):
 
 
 def bytes_to_string(data):
+    encoding = 'utf-8'
     try:
-        encoding = chardet.detect(data)['encoding']
-    except:
-        print("could not detect bytes encoding, assume utf-8")
-        encoding = 'utf-8'
-    try:
-        string = data.decode(encoding, 'replace')
+        partialString = data.decode(encoding, 'replace')
+        try:
+            charSetRegex = re.compile("charset=\"?([a-zA-Z0-9\\-]*)\"?")
+            results = charSetRegex.search(partialString)
+            if(results != None):
+                encoding = results.group(1)
+                string = data.decode(encoding, 'replace')
+            else:
+                string = partialString
+        except:
+            print("Fail trying to get declared bytes encoding (charset) using regular expression")
+            try:
+                encoding = chardet.detect(data)['encoding']
+                string = data.decode(encoding, 'replace')
+            except:
+                print("could not detect bytes encoding, assume utf-8")
+                string = partialString
     except:
         print("failed to decode bytes to string")
         return ""
-    
     return string
 
 


### PR DESCRIPTION
It was necessary because Chardet can't detect, for example, ISO-8859-1. For the data received from Vagalume, which uses ISO-8859-1, chardet.detect(data) returns IBM855, resulting in inappropriate characters in  the final lyrics, specially in Portuguese.
Using a regular expression, it's possible to search for charset declaration in the data received from the server, so the data can be decoded correctly. Generally there is a declaration in a meta tag, in the beginning of the HTML, but with regular expression, the function can find it wherever it is.